### PR TITLE
fix (Droplet) Small fixes [100%]

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,8 +54,10 @@
   "homepage": "https://github.com/dabbler0/droplet",
   "dependencies": {
     "acorn": "^1.2.2",
-    "sax": "^1.1.1",
     "antlr4": "latest",
-    "parse5": "1.5.1"
+    "lodash.clonedeep": "^4.2.0",
+    "lodash.isequal": "^4.1.0",
+    "parse5": "1.5.1",
+    "sax": "^1.1.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -56,6 +56,6 @@
     "acorn": "^1.2.2",
     "sax": "^1.1.1",
     "antlr4": "latest",
-    "parse5": "latest"
+    "parse5": "1.5.1"
   }
 }

--- a/src/helper.coffee
+++ b/src/helper.coffee
@@ -153,29 +153,6 @@ exports.string = (arr) ->
     last = exports.connect last, el
   return last
 
-exports.deepCopy = deepCopy = (a) ->
-  if a instanceof Object
-    newObject = {}
+exports.deepCopy = deepCopy = require 'lodash.clonedeep'
 
-    for key, val of a
-      newObject[key] = deepCopy val
-
-    return newObject
-
-  else
-    return a
-
-exports.deepEquals = deepEquals = (a, b) ->
-  if a instanceof Object and b instanceof Object
-    for own key, val of a
-      unless deepEquals b[key], val
-        return false
-
-    for own key, val of b when not key of a
-      unless deepEquals a[key], val
-        return false
-
-    return true
-  else
-    return a is b
-
+exports.deepEquals = deepEquals = require 'lodash.isequal'


### PR DESCRIPTION
**Status**: 100%
_Review Requested_
- [x] fix issue with api change in parse5 library
- [x] use lodash isequal and clonedeep to avoid issue
  - we have added a function to the proto of array. this in turn led to a strange issue with the `deepCopy` and `deepEquals` previously used. the lodash alternative eliminated this issue. 
